### PR TITLE
Ajout d’un script de build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Sqlite/tbot_bdd.sqlite
 Sqlite/tbot_bdd copy.sqlite
 Configuration/config.json
 Configuration/Secret/config_Token_Client.json
+*.spec
+build/
+dist/

--- a/TBoT-Twitch/tbot/tbot_com.py
+++ b/TBoT-Twitch/tbot/tbot_com.py
@@ -7,7 +7,6 @@ import os
 from pygame import mixer
 import aiofiles
 from datetime import datetime
-import winreg
 
 with open("./Configuration/config.json", "r") as fichier:
     CONFIG = json.load(fichier)
@@ -27,15 +26,17 @@ ligne_overlay = []
 
 
 def get_reg(name, reg_path):
-    try:
-        registry_key = winreg.OpenKey(
-            winreg.HKEY_LOCAL_MACHINE, reg_path, 0, winreg.KEY_READ
-        )
-        value, regtype = winreg.QueryValueEx(registry_key, name)
-        winreg.CloseKey(registry_key)
-        return value
-    except WindowsError:
-        return None
+    if os.name == "nt":
+        import winreg
+        try:
+            registry_key = winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE, reg_path, 0, winreg.KEY_READ
+            )
+            value, regtype = winreg.QueryValueEx(registry_key, name)
+            winreg.CloseKey(registry_key)
+            return value
+        except WindowsError:
+            return None
 
 
 URLMOD = get_reg(

--- a/build.py
+++ b/build.py
@@ -1,0 +1,28 @@
+import shutil
+import PyInstaller.__main__
+
+try:
+    shutil.rmtree("dist")
+except FileNotFoundError:
+    pass
+
+PyInstaller.__main__.run([
+    "--onefile",
+    "--hidden-import", "tbot.tbot_client",
+    "TBoT-Twitch/main.py"
+])
+
+PyInstaller.__main__.run([
+    "--onefile",
+    "configure-secrets.py"
+])
+
+for folder in (
+    "Configuration",
+    "Data",
+    "Language",
+    "Sounds",
+    "Sqlite",
+    "TBoT_Overlay"
+):
+    shutil.copytree(folder, f"dist/{folder}")

--- a/configure-secrets.py
+++ b/configure-secrets.py
@@ -1,0 +1,25 @@
+import json
+
+def ask(msg, type = str):
+    while True:
+        try:
+            return type(input(f"{msg}: "))
+        except ValueError:
+            print("Wrong type")
+            pass
+
+new_config = {
+    "USERNAME": ask("Username"),
+    "TOKEN": ask("Access token"),
+    "REFRESH": ask("Refresh token"),
+    "ID": ask("Client ID"),
+    "USER_ID": ask("User ID", int),
+    "NICK": ask("Nickname"),
+    "PREFIX": ask("Prefix"),
+    "CHANNEL": ask("Channel"),
+}
+
+with open("./Configuration/Secret/config_Token_Client.json", "w") as file:
+    file.write(json.dumps(new_config, indent=4))
+
+print("New secret configuration written successfully")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pyaudio>=0.2.13
 yt_dlp>=2023.02.17
 aiosqlite>=0.18.0
 aiofiles>=23.1.0
+pygame
+winreg ; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiosqlite>=0.18.0
 aiofiles>=23.1.0
 pygame
 winreg ; platform_system == "Windows"
+pyinstaller


### PR DESCRIPTION
Cette pull request ajoute un script de build qui permet de générer un exécutable du code afin de faciliter l’exécution pour le streamer, qui n’a alors pas besoin d’installer Python et les dépendances du projet. 
De plus, pour lui éviter de devoir éditer le fichier de configuration des secrets à la main, il compile aussi un script, `configure-secrets`, qui lui demande successivement chaque paramètre à mettre dans la configuration.

Le script `build.py` génère un dossier `dist` contenant deux exécutable, `main` et `configure-secrets` (ou `main.exe` et `configure-secrets.exe` respectivement sous Windows), 
et les dossiers de configuration et de données dont a besoin TwitchSurvivors pour fonctionner.

```
$ python build.py
$ ls dist
Configuration  configure-secrets  Data  Language  main  Sounds  Sqlite  TBoT_Overlay
```

Note : Étant donné que le projet utilise beaucoup de chemins relatifs, il est nécessaire de lancer ces deux exécutables depuis le bon dossier. 
Je ne sais pas si les gestionnaires de fichiers de Windows et Ubuntu lancent les exécutables depuis le répertoire courant (il semblerait que oui).

Note 2 : J’ai très peu testé cette PR. Le build fonctionne et les deux fichiers s’exécutent sans erreur, mais je n’ai pas testé les commandes du bot, etc.

@Fr-Dae